### PR TITLE
Add BOM.md

### DIFF
--- a/BOM.md
+++ b/BOM.md
@@ -1,0 +1,48 @@
+# Bill of Materials
+
+## Plated, 1515 Extrusion, 6mm Belts
+
+### Source:
+- 2x Cut Aluminum Plates using xyjplate[x2].dxf
+- 1515 profile extrusion, e.g. [from Misumi](https://us.misumi-ec.com/vona2/detail/110300465870/)
+- M3 tap to use on the extrusion
+
+### Print: 
+- xyj-left-lower-plated.stl
+- xyj-right-lower-plated.stl
+- 1515 6mm Trailhead - XY Joint - Left Top.stl
+- 1515 6mm Trailhead - XY Joint - Right Top.stl
+- 2x misumi1515nodropsquare6mm.stl
+- 18x misumi1515nodropsquare.stl (You may have leftovers)
+
+### Small Parts:
+- 4x M3 heatset inserts
+    - Insert into xyj-*-lower-plated printed parts
+- 2x 6mm pulley for belts
+- 8x F695 bearing (Four greater than the stock XY joints)
+- 18x Roll/Slide-in M3 T-nuts for 1515 Extrusions
+    - choose the correct type for your 1515 profile. LDO and Makerbeam are different.
+- 20x M3x6mm BHCS
+    - 2x through rear of extrusion
+    - 10x through X-axis MGN rail (for 300mm spec / 350mm rail / 380mm extrusion)
+    - 8x through plates into Y axis MGN carriage
+- 4x M3x8mm SHCS
+    - 4x through upper printed joints into extrusion
+- 4x M3x12mm SHCS
+    - 2x through plate, into heatset in lower printed joint
+    - 2x into extrusion end
+- 2x M3x16mm SHCS
+    - 2x through plate, into heatset in lower printed joint
+- 2x M3x20mm SHCS
+    - 2x through plate, through lower printed joint, into extrusion
+- 8x M3 washer
+    - 2x for the M3x12 SHCS into the ends of the extrusion
+    - 6x for the M3 SHCS screws through bottom of the plates
+    - No washers for the M3x6 BHCS screws that go into the carriages
+- 2x M5x40mm SHCS
+    - 2x through entire XY joint from top to bottom.
+- 2x M5 washer
+    - 2x between plate and nut
+- 2x M5 nut
+    - Secure the M5x40mm SHCS at the bottom of each plate. Tighten with a wrench + pliers
+- 4x 5mm x 35mm shafts (These are different from the 40mm shafts used in the regular pins mod!)


### PR DESCRIPTION
Adds a bill of materials for one specific variant of trailhead, with notes and usage instructions.

If we prefer to split usage instructions to a specific assembly section, we can do that instead